### PR TITLE
Enforce ActiveRecord 4.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'sinatra'
-gem 'activerecord', :require => 'active_record'
+gem 'activerecord', '4.2.5', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 gem 'rake'
 gem 'require_all'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,44 @@
 GIT
   remote: https://github.com/bmabey/database_cleaner.git
-  revision: b393fa81fc864805e79913f4377e316be40f8900
+  revision: a8d68a8b253d2ab5fcc07175db4ade27b6494d5b
   specs:
-    database_cleaner (1.6.3)
+    database_cleaner (1.7.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (5.1.5)
-      activesupport (= 5.1.5)
-    activerecord (5.1.5)
-      activemodel (= 5.1.5)
-      activesupport (= 5.1.5)
-      arel (~> 8.0)
-    activesupport (5.1.5)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
+      builder (~> 3.1)
+    activerecord (4.2.5)
+      activemodel (= 4.2.5)
+      activesupport (= 4.2.5)
+      arel (~> 6.0)
+    activesupport (4.2.5)
       i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    arel (8.0.0)
-    capybara (2.18.0)
+    arel (6.0.4)
+    builder (3.2.3)
+    capybara (3.1.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     daemons (1.2.6)
     diff-lcs (1.3)
-    eventmachine (1.2.5)
+    eventmachine (1.2.7)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    json (1.8.6)
     method_source (0.9.0)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
@@ -46,13 +50,13 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-protection (2.0.1)
       rack
-    rack-test (0.8.3)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
-    rake (12.3.0)
-    require_all (1.5.0)
+    rake (12.3.1)
+    require_all (2.0.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -92,7 +96,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
+  activerecord (= 4.2.5)
   capybara
   database_cleaner!
   pry
@@ -107,4 +111,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.16.1
+   1.16.0


### PR DESCRIPTION
For #63 
I chose `4.2.5` to be consistent with what is taught in [Sinatra Activerecord Setup](https://github.com/learn-co-curriculum/sinatra-activerecord-setup)

Given the current discussion in #curriculum, I simply modified the `Gemfile.lock` instead of removing it outright. 